### PR TITLE
[TASK] Use same window name as the core

### DIFF
--- a/Classes/Hooks/DatabaseRecordListHooks.php
+++ b/Classes/Hooks/DatabaseRecordListHooks.php
@@ -124,7 +124,7 @@ class DatabaseRecordListHooks implements RecordListHookInterface
 
         $button = '
             <a  class="btn btn-default t3-impersonate-button" 
-                href="'.$uri.'" target="_blank" 
+                href="'.$uri.'" target="newTYPO3frontendWindow" 
                 title="'.$buttonText.'">
 	                '.$iconMarkup.'	
             </a>';


### PR DESCRIPTION
Instead of constantly opening a new window, the same window should be used that the core also opens when clicking on the eye icon.